### PR TITLE
Remove checks for reserved fields in decode stage for FENCE

### DIFF
--- a/rtl/core/kronos_ID.sv
+++ b/rtl/core/kronos_ID.sv
@@ -289,7 +289,7 @@ always_comb begin
       case(funct3)
         3'b000: begin // FENCE
           // This is a NOP
-          if (funct7[6:3] == '0 && rs1 == '0 && rd =='0) instr_valid = 1'b1;
+          instr_valid = 1'b1;
         end
         3'b001: begin // FENCE.I
           if (IR[31:20] == 12'b0 && rs1 == '0 && rd =='0) begin


### PR DESCRIPTION
Hi there!

The RISC-V specification says

> The unused fields in the FENCE instructions—rs1 and rd—are reserved for finer-grain fences in future extensions. For forward compatibility, base implementations shall ignore these fields.

> Likewise, many fm and predecessor/successor set settings in Table 2.2 are also reserved for future use. Base implementations shall treat all such reserved configurations as normal fences with fm=0000.

Therefore, it seems that these checks should be removed.

Thanks!
Flavien